### PR TITLE
chore: Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- Add `GtkIcon` wrapper for GTK icons
+
 ## 2.1.0
 
 - Migrate to Flutter 3.10 and Dart 3.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  gtk: ^2.0.0
+  gtk: ^2.2.0
   provider: ^6.0.5
   yaru: ^10.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: GTK+ utilities for Flutter Linux applications.
 homepage: https://github.com/ubuntu-flutter-community/gtk.dart
 repository: https://github.com/ubuntu-flutter-community/gtk.dart
 issue_tracker: https://github.com/ubuntu-flutter-community/gtk.dart/issues
-version: 2.1.0
+version: 2.2.0
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Bump to 2.2.0, with a manual local publish to follow.

*We should definitely look at automating and streamlining the release process for these .dart repositories.*

---

UDENG-9784